### PR TITLE
Start working on travis integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
-
+dist/dnsbench*
+dist/*.docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: go
+go:
+- "1.10"
+script:
+- make test
+- make e2e

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,11 @@
+.PHONY: build test e2e
+
+test:
+	go test -v ./...
+
+build: dist/dnsbench
+dist/dnsbench:
+	go build -o dist/dnsbench dnsbench.go
+
+e2e: dist/dnsbench
+	./dist/functional-tests.sh

--- a/dist/functional-tests.sh
+++ b/dist/functional-tests.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -eo pipefail
+
+echo "Testing local resolver mode..."
+echo "example.com" | ./dist/dnsbench -local -concurrency 1 -count 10
+
+echo "Testing external nameserver mode..."
+echo "example.com" | ./dist/dnsbench -concurrency 1 -count 10 8.8.8.8


### PR DESCRIPTION
Adds a very basic travis file, makefile, and stub e2e test script.
Intended to be the starting point for future improvements to the test
and build system for dnsbench.